### PR TITLE
fix: update hardcoded colors for light theme compatibility

### DIFF
--- a/src/Boards/Board.css
+++ b/src/Boards/Board.css
@@ -23,7 +23,7 @@
   flex-wrap: nowrap;
   justify-content: space-evenly;
   align-items: center;
-  color: white;
+  color: rgb(172, 172, 172);
 }
 
 .popover-content {
@@ -31,7 +31,7 @@
   border: 2px solid #494949;
   border-radius: 10px;
   padding: 10px;
-  color: white;
+  color: rgb(172, 172, 172);
 }
 
 .detail-content {

--- a/src/Loading/Loading.css
+++ b/src/Loading/Loading.css
@@ -14,7 +14,7 @@
   display: block;
   margin: 15px auto;
   position: relative;
-  color: #fff;
+  color: rgb(172, 172, 172);
   box-sizing: border-box;
   animation: animloader 1s linear infinite alternate;
 }

--- a/stories/general.css
+++ b/stories/general.css
@@ -32,7 +32,7 @@ input[type='number'] {
 }
 
 .editorFieldContainer > :first-child {
-  color: white;
+  color: rgb(172, 172, 172);
 }
 
 .editorMetricInput {


### PR DESCRIPTION
## Why?

Discovered an issue with the light theme while working on https://github.com/liatrio/react-dora-charts/pull/9. Certain UI text elements were hardcoded to use the color 'white', making them invisible against a light background. By updating these colors to `rgb(172, 172, 172)`, the text now matches the rest of the UI and is readable on light and dark themes.

## What Changed?

- Updated hardcoded 'white' color values to 'rgb(172, 172, 172)' in Board.css, Loading.css, and general.css files.
- Ensured consistency in text color across different UI components to enhance readability in the light theme.

## Examples of Issue

Example of dark theme:
![dark-before](https://github.com/user-attachments/assets/b4cda376-7071-4d87-b3ed-d410d954e260)
![dark-after](https://github.com/user-attachments/assets/31017ec3-0af2-47b4-84cd-0ae2c7c9e509)

Example of light theme:
![light-before](https://github.com/user-attachments/assets/57a26797-f018-47c2-b190-0e114674eaa4)
![light-after](https://github.com/user-attachments/assets/0f65654b-0735-4269-b586-2e92b2589fe0)
