### PR TITLE
chore: rollup project in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build the project
+        run: npm run rollup
+
       - name: Bump and Release
         env:
           GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}


### PR DESCRIPTION
The dist was missing from the release workflow, so I added a step to build the project using `npm run rollup`. 

This will ensure that the project is built before the publish.