### PR TITLE
chore: add optional dependency for build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      #      - name: Install dependencies
-      #        run: npm install
+      - name: Install dependencies
+        run: npm install
 
       - name: Build the project
         run: npm run rollup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: 'Release'
 on:
   push:
     branches:
-      - main
+      - release-testing
     paths-ignore:
       - 'LICENSE'
       - 'CHANGELOG.md'
@@ -40,8 +40,8 @@ jobs:
       - name: Build the project
         run: npm run rollup
 
-      - name: Bump and Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+#      - name: Bump and Release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}
+#          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+#        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm install
+      #      - name: Install dependencies
+      #        run: npm install
 
       - name: Build the project
         run: npm run rollup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: 'Release'
 on:
   push:
     branches:
-      - release-testing
+      - main
     paths-ignore:
       - 'LICENSE'
       - 'CHANGELOG.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Build the project
         run: npm run rollup
-#      - name: Bump and Release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}
-#          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-#        run: npx semantic-release
+
+      - name: Bump and Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Build the project
         run: npm run rollup
-
 #      - name: Bump and Release
 #        env:
 #          GITHUB_TOKEN: ${{ secrets.TAGGING_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,9 @@
         "tslib": "^2.6.2",
         "typescript": "^5.4.5"
       },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.18.0"
+      },
       "peerDependencies": {
         "react": "^18.0.0",
         "typescript": "^5.0.0"
@@ -4234,6 +4237,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
+      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@semantic-release/changelog": {

--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
     "recharts": "^2.12.7",
     "uuid": "^10.0.0"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.18.0"
+  },
   "prettier": "@spotify/prettier-config"
 }


### PR DESCRIPTION
The pipeline was failing saying: 

```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional 
dependencies (https://github.com/npm/cli/issues/4828). 

Please try `npm i` again after removing both package-lock.json and node_modules directory.
```

Found [references](https://github.com/vitejs/vite/discussions/15532) to the error, and that some were able to resolve by adding the `@rollup/rollup-linux-x64-gnu` package as an optional dependency.

After adding the change, the pipeline is now passing.