### PR TITLE
fix: updated readme and package license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
-# Badges
-
-[![CodeQL](https://github.com/liatrio/react-dora-charts/actions/workflows/codeql.yml/badge.svg)](https://github.com/liatrio/react-dora-charts/actions/workflows/codeql.yml)
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-[![Release](https://github.com/liatrio/react-dora-charts/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/liatrio/react-dora-charts/actions/workflows/release.yml)
-
-![GitHub top language](https://img.shields.io/github/languages/top/liatrio/react-dora-charts)
-
 # React DORA Charts
+
+[![CodeQL](https://github.com/liatrio/react-dora-charts/actions/workflows/codeql.yml/badge.svg)](https://github.com/liatrio/react-dora-charts/actions/workflows/codeql.yml) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Release](https://github.com/liatrio/react-dora-charts/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/liatrio/react-dora-charts/actions/workflows/release.yml) ![GitHub top language](https://img.shields.io/github/languages/top/liatrio/react-dora-charts)
 
 This component library contains charts for the standard DORA metrics.
 
@@ -31,7 +23,7 @@ yarn add @liatrio/react-dora-charts
 To use these charts, you can do as follows:
 
 ```js
-import { DeploymentFrequency, fetchData } from `react-dora-charts`
+import { DeploymentFrequency, fetchData } from `@liatrio/react-dora-charts`
 ...
 const fetchedData = fetchData(fetchProps, onSuccess, onFailure)
 ...

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepare": "husky"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "peerDependencies": {
     "react": "^18.0.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
This pull request includes updates to the `README.md` file for better readability and a license change in the `package.json` file. The most important changes include reformatting the badges section, correcting an import statement, and updating the license type.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R4): Reformatted the badges section to be more readable by placing all badges on a single line.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R26): Corrected the import statement to use the correct package name `@liatrio/react-dora-charts`.

License update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43-R43): Changed the license from `ISC` to `Apache-2.0`.